### PR TITLE
Fix ruff config options

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -197,11 +197,11 @@ force-sort-within-sections = true
 known-first-party = ["app"]
 
 # Use hanging indents for long imports
-multi-line-output = 3
-include-trailing-comma = true
-force-grid-wrap = 0
-combine-as-imports = true
-line-length = 120
+multi_line_output = 3
+include_trailing_comma = true
+force_grid_wrap = 0
+combine_as_imports = true
+line_length = 120
 
 [lint.mccabe]
 # McCabe complexity threshold


### PR DESCRIPTION
## Summary
- fix invalid isort options in `ruff.toml`
- attempt to run `setup_and_run.py` to install dependencies

## Testing
- `python3 setup_and_run.py --backend-only --skip-tests` *(fails: Could not find pydantic due to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6840df111bb88320ae422e81c6d63964