### PR TITLE
Use Docling for source extraction

### DIFF
--- a/tests/test_document_reading.py
+++ b/tests/test_document_reading.py
@@ -3,19 +3,14 @@
 Testes específicos para leitura de documentos
 """
 
-import pytest
-
-# Check dependencies early
-pytest.importorskip("PyPDF2")
-pytest.importorskip("python_docx")
-pytest.importorskip("openpyxl")
-
 # Standard library imports
 import asyncio
 import contextlib
 from pathlib import Path
 import sys
 import tempfile
+
+import pytest
 
 # Adicionar o diretório raiz ao path
 sys.path.insert(0, str(Path(__file__).parent.parent))


### PR DESCRIPTION
## Summary
- replace PDF and DOCX parsing in SourceService with Docling
- initialize DocumentConverter in SourceService
- remove optional dependency checks from document reading tests

## Testing
- `ruff check app/knowledge/services/source_service.py tests/test_document_reading.py`
- `pytest -q tests/test_document_reading.py` *(fails: ModuleNotFoundError: No module named 'pydantic_settings')*

------
https://chatgpt.com/codex/tasks/task_e_6845a13c79b083209105cf7b59ee91a9