### PR TITLE
Remove unused document processing libs

### DIFF
--- a/requirements-documents.txt
+++ b/requirements-documents.txt
@@ -2,7 +2,6 @@
 # Funcionalidades avançadas de processamento de documentos
 
 # Basic document processing
-python-docx~=1.1.2
 html2text~=2025.4.15
 
 # Advanced document processing with Docling

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,9 +33,6 @@ websockets~=15.0.1
 python-multipart~=0.0.20
 
 # Document processing libraries
-PyPDF2~=3.0.1
-python-docx~=1.1.2
-openpyxl~=3.1.5
 pandas
 
 # Advanced document processing with Docling

--- a/setup.py
+++ b/setup.py
@@ -35,9 +35,6 @@ setup(
         "pydantic_core>=2.27.2,<2.35.0",
         "colorama~=0.4.6",
         # Document processing libraries
-        "PyPDF2~=3.0.1",
-        "python-docx~=1.1.2",
-        "openpyxl~=3.1.5",
         "pandas",
         # Advanced document processing with Docling
         "docling>=2.34,<2.37",


### PR DESCRIPTION
## Summary
- update requirements to drop python-docx, PyPDF2 and openpyxl
- remove the same from setup.py

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement pydantic~=2.10.6)*
- `python -m pytest tests/test_document_reading.py -vv` *(fails: ModuleNotFoundError: No module named 'pydantic_settings')*

------
https://chatgpt.com/codex/tasks/task_e_6845eaf647688320b7e5820f0556fe98